### PR TITLE
XML Generation Standardization

### DIFF
--- a/Sources/SwiftTAK/COT/COTMessage.swift
+++ b/Sources/SwiftTAK/COT/COTMessage.swift
@@ -33,8 +33,10 @@ public struct COTPositionInformation {
 
 public class COTMessage: NSObject {
     
+    static let XML_HEADER = "<?xml version=\"1.0\" standalone=\"yes\"?>"
     static public let DEFAULT_COT_TYPE = "a-f-G-U-C"
-    static public let DEFAULT_HOW = "m-g"
+    static public let DEFAULT_CHAT_COT_TYPE = "b-t-f"
+    static public let DEFAULT_HOW = HowType.MachineGPSDerived.rawValue
     static public let DEFAULT_ERROR_NUMBER = "999999.0"
     public let COT_EVENT_VERSION = "2.0"
     
@@ -74,7 +76,7 @@ public class COTMessage: NSObject {
         let latitude: String = positionInfo.latitude.description
         let longitude: String = positionInfo.longitude.description
         
-        var cotEvent = COTEvent(version: COT_EVENT_VERSION, uid: deviceID, type: eventType, how: "h-g-i-g-o", time: Date(), start: Date(), stale: Date().addingTimeInterval(cotTimeout))
+        var cotEvent = COTEvent(version: COT_EVENT_VERSION, uid: deviceID, type: eventType, how: HowType.HumanGIGO.rawValue, time: Date(), start: Date(), stale: Date().addingTimeInterval(cotTimeout))
         
         let cotPoint = COTPoint(lat: latitude, lon: longitude, hae: heightAboveElipsoid, ce: circularError, le: linearError)
         
@@ -82,13 +84,13 @@ public class COTMessage: NSObject {
         
         var cotDetail = COTDetail()
         
-        cotDetail.childNodes.append(COTLink(relation: "p-p", type: cotType, uid: deviceID))
+        cotDetail.childNodes.append(COTLink(relation: LinkType.ParentProducer.rawValue, type: cotType, uid: deviceID))
         cotDetail.childNodes.append(COTContact(callsign: "\(callSign)-Alert"))
         cotDetail.childNodes.append(COTEmergency(cancel: isCancelled, type: emergencyType, callsign: callSign))
                                     
         cotEvent.childNodes.append(cotDetail)
         
-        return "<?xml version=\"1.0\" standalone=\"yes\"?>" + cotEvent.toXml()
+        return COTMessage.XML_HEADER + cotEvent.toXml()
     }
     
     public func generateCOTXml(cotType: String = DEFAULT_COT_TYPE,
@@ -129,7 +131,7 @@ public class COTMessage: NSObject {
         cotEvent.childNodes.append(cotPoint)
         cotEvent.childNodes.append(cotDetail)
         
-        return "<?xml version=\"1.0\" standalone=\"yes\"?>" + cotEvent.toXml()
+        return COTMessage.XML_HEADER + cotEvent.toXml()
     }
     
     public func generateChatMessage(message: String,
@@ -137,8 +139,8 @@ public class COTMessage: NSObject {
                                     receiver: String = TAKConstants.DEFAULT_CHATROOM_NAME,
                                     destinationUrl: String,
                                     positionInfo: COTPositionInformation = COTPositionInformation()) -> String {
-        let cotType = "b-t-f"
-        let cotHow = "h-g-i-g-o"
+        let cotType = COTMessage.DEFAULT_CHAT_COT_TYPE
+        let cotHow = HowType.HumanGIGO.rawValue
         let ONE_DAY = 60.0*60.0*24.0
         let eventTime = Date()
         let stale = Date().addingTimeInterval(ONE_DAY)
@@ -163,7 +165,7 @@ public class COTMessage: NSObject {
         let remarksSource = "BAO.F.TAKTracker.\(from)"
         
         let cotChat = COTChat(senderCallsign: from, messageID: messageID)
-        let cotLink = COTLink(relation: "p-p", type: "a-f-G-U-C", uid: messageID)
+        let cotLink = COTLink(relation: LinkType.ParentProducer.rawValue, type: "a-f-G-U-C", uid: messageID)
         let cotRemarks = COTRemarks(source: remarksSource, timestamp: Date().ISO8601Format(), message: message)
         
         cotDetail.childNodes.append(cotChat)
@@ -172,6 +174,6 @@ public class COTMessage: NSObject {
         
         cotEvent.childNodes.append(cotDetail)
         
-        return "<?xml version=\"1.0\" standalone=\"yes\"?>" + cotEvent.toXml()
+        return COTMessage.XML_HEADER + cotEvent.toXml()
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTChat.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTChat.swift
@@ -24,20 +24,14 @@ public struct COTChat : COTNode {
     public var senderCallsign:String = ""
     public var messageID:String = UUID().uuidString
     
-    public func makeAttribute(attrName: String, attrVal: String) -> String {
-        if(attrVal.isEmpty) { return "" }
-        return "\(attrName)='\(attrVal)' "
-    }
-    
     public func toXml() -> String {
-        return "<__chat " +
-        makeAttribute(attrName: "id", attrVal: id) +
-        makeAttribute(attrName: "chatroom", attrVal: chatroom) +
-        makeAttribute(attrName: "groupOwner", attrVal: groupOwner) +
-        makeAttribute(attrName: "parent", attrVal: parent) +
-        makeAttribute(attrName: "senderCallsign", attrVal: senderCallsign) +
-        makeAttribute(attrName: "messageID", attrVal: messageID) +
-        ">" +
-        "</__chat>"
+        var attrs: [String:String] = [:]
+        attrs["id"] = id
+        attrs["chatroom"] = chatroom
+        attrs["groupOwner"] = groupOwner
+        attrs["parent"] = parent
+        attrs["senderCallsign"] = senderCallsign
+        attrs["messageID"] = messageID
+        return COTXMLHelper.generateXML(nodeName: "__chat", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTContact.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTContact.swift
@@ -19,10 +19,10 @@ public struct COTContact : COTNode {
     public var callsign:String
     
     public func toXml() -> String {
-        return "<contact " +
-        "endpoint='\(endpoint)' " +
-        "phone='\(phone)' " +
-        "callsign='\(callsign)'" +
-        "></contact>"
+        var attrs: [String:String] = [:]
+        attrs["endpoint"] = endpoint
+        attrs["phone"] = phone
+        attrs["callsign"] = callsign
+        return COTXMLHelper.generateXML(nodeName: "contact", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTDetail.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTDetail.swift
@@ -13,10 +13,11 @@ public struct COTDetail : COTNode {
     }
     
     public var childNodes:[COTNode] = []
-    
+
     public func toXml() -> String {
-        return "<detail>" +
-        childNodes.map { $0.toXml() }.joined() +
-        "</detail>"
+        return COTXMLHelper.generateXML(
+            nodeName: "detail",
+            attributes: [:],
+            childNodes: childNodes)
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTEmergency.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTEmergency.swift
@@ -19,10 +19,9 @@ public struct COTEmergency : COTNode {
     public var callsign: String
     
     public func toXml() -> String {
-        return "<emergency " +
-        "cancel='\(cancel.description)' " +
-        "type='\(type)'>" +
-        callsign +
-        "</emergency>"
+        var attrs: [String:String] = [:]
+        attrs["cancel"] = cancel.description
+        attrs["type"] = type.description
+        return COTXMLHelper.generateXML(nodeName: "emergency", attributes: attrs, message: callsign)
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTEvent.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTEvent.swift
@@ -29,16 +29,18 @@ public struct COTEvent : COTNode {
     public var childNodes:[COTNode] = []
     
     public func toXml() -> String {
-        return "<event " +
-        "version='\(version)' " +
-        "uid='\(uid)' " +
-        "type='\(type)' " +
-        "how='\(how)' " +
-        "time='\(ISO8601DateFormatter().string(from: time))' " +
-        "start='\(ISO8601DateFormatter().string(from: start))' " +
-        "stale='\(ISO8601DateFormatter().string(from: stale))'" +
-        ">" +
-        childNodes.map { $0.toXml() }.joined() +
-        "</event>"
+        var attrs: [String:String] = [:]
+        attrs["version"] = version
+        attrs["uid"] = uid
+        attrs["type"] = type
+        attrs["how"] = how
+        attrs["time"] = ISO8601DateFormatter().string(from: time)
+        attrs["start"] = ISO8601DateFormatter().string(from: start)
+        attrs["stale"] = ISO8601DateFormatter().string(from: stale)
+        
+        return COTXMLHelper.generateXML(
+            nodeName: "event",
+            attributes: attrs,
+            childNodes: childNodes)
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTGroup.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTGroup.swift
@@ -17,9 +17,9 @@ public struct COTGroup : COTNode {
     public var role:String
     
     public func toXml() -> String {
-        return "<__group " +
-        "name='\(name)' " +
-        "role='\(role)'" +
-        "></__group>"
+        var attrs: [String:String] = [:]
+        attrs["name"] = name
+        attrs["role"] = role
+        return COTXMLHelper.generateXML(nodeName: "__group", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTLink.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTLink.swift
@@ -25,13 +25,13 @@ public struct COTLink : COTNode {
     public var callsign: String = ""
     
     public func toXml() -> String {
-        return "<link " +
-        "parent_callsign='\(parentCallsign)' " +
-        "production_time='\(productionTime)' " +
-        "relation='\(relation)' " +
-        "type='\(type)' " +
-        "uid='\(uid)' " +
-        "callsign='\(callsign)' " +
-        "></link>"
+        var attrs: [String:String] = [:]
+        attrs["parent_callsign"] = parentCallsign
+        attrs["production_time"] = productionTime
+        attrs["relation"] = relation
+        attrs["type"] = type
+        attrs["uid"] = uid
+        attrs["callsign"] = callsign
+        return COTXMLHelper.generateXML(nodeName: "link", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTPoint.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTPoint.swift
@@ -23,12 +23,12 @@ public struct COTPoint : COTNode {
     public var le:String
     
     public func toXml() -> String {
-        return "<point " +
-        "lat='\(lat)' " +
-        "lon='\(lon)' " +
-        "hae='\(hae)' " +
-        "ce='\(ce)' " +
-        "le='\(le)'" +
-        "></point>"
+        var attrs: [String:String] = [:]
+        attrs["lat"] = lat
+        attrs["lon"] = lon
+        attrs["hae"] = hae
+        attrs["ce"] = ce
+        attrs["le"] = le
+        return COTXMLHelper.generateXML(nodeName: "point", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTRemarks.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTRemarks.swift
@@ -20,13 +20,9 @@ public struct COTRemarks : COTNode {
     public var message: String = ""
     
     public func toXml() -> String {
-        let sourceAttr = source.isEmpty ? "" : "source='\(source)' "
-        let timestampAttr = timestamp.isEmpty ? "" : "timestamp='\(timestamp)' "
-        return "<remarks " +
-        sourceAttr +
-        timestampAttr + 
-        ">" +
-        message +
-        "</remarks>"
+        var attrs: [String:String] = [:]
+        attrs["source"] = source
+        attrs["timestamp"] = timestamp
+        return COTXMLHelper.generateXML(nodeName: "remarks", attributes: attrs, message: message)
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTServerDestination.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTServerDestination.swift
@@ -16,9 +16,8 @@ public struct COTServerDestination : COTNode {
     public var destinations: String = ""
     
     public func toXml() -> String {
-        return "<__serverdestination " +
-        "destinations='\(destinations)'" + 
-        ">" +
-        "</__serverdestination>"
+        var attrs: [String:String] = [:]
+        attrs["destinations"] = destinations
+        return COTXMLHelper.generateXML(nodeName: "__serverdestination", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTStatus.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTStatus.swift
@@ -15,8 +15,8 @@ public struct COTStatus : COTNode {
     public var battery:String
     
     public func toXml() -> String {
-        return "<status " +
-        "battery='\(battery)'" +
-        "></status>"
+        var attrs: [String:String] = [:]
+        attrs["battery"] = battery
+        return COTXMLHelper.generateXML(nodeName: "status", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTTakV.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTTakV.swift
@@ -21,11 +21,11 @@ public struct COTTakV : COTNode {
     public var version:String
     
     public func toXml() -> String {
-        return "<takv " +
-        "device='\(device)' " +
-        "platform='\(platform)' " +
-        "os='\(os)' " +
-        "version='\(version)'" +
-        "></takv>"
+        var attrs: [String:String] = [:]
+        attrs["device"] = device
+        attrs["platform"] = platform
+        attrs["os"] = os
+        attrs["version"] = version
+        return COTXMLHelper.generateXML(nodeName: "takv", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTTrack.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTTrack.swift
@@ -17,9 +17,9 @@ public struct COTTrack : COTNode {
     public var course:String
     
     public func toXml() -> String {
-        return "<track " +
-        "speed='\(speed)' " +
-        "course='\(course)'" +
-        "></track>"
+        var attrs: [String:String] = [:]
+        attrs["speed"] = speed
+        attrs["course"] = course
+        return COTXMLHelper.generateXML(nodeName: "track", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTUid.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTUid.swift
@@ -15,8 +15,8 @@ public struct COTUid : COTNode {
     public var callsign:String
     
     public func toXml() -> String {
-        return "<uid " +
-        "Droid='\(callsign)'" +
-        "></uid>"
+        var attrs: [String:String] = [:]
+        attrs["Droid"] = callsign
+        return COTXMLHelper.generateXML(nodeName: "uid", attributes: attrs, message: "")
     }
 }

--- a/Sources/SwiftTAK/COT/COTModels/COTVideo.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTVideo.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Cory Foy on 10/9/23.
+//
+
+import Foundation
+
+public struct COTVideo : COTNode {
+    public var url: String
+    public var uid: String = ""
+    
+    public func toXml() -> String {
+        var attrs: [String:String] = [:]
+        attrs["url"] = url
+        attrs["uid"] = uid
+        
+        return COTXMLHelper.generateXML(nodeName: "__video", attributes: attrs, message: "")
+    }
+}

--- a/Sources/SwiftTAK/COT/COTModels/COTVideo.swift
+++ b/Sources/SwiftTAK/COT/COTModels/COTVideo.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  COTVideo.swift
 //  
 //
 //  Created by Cory Foy on 10/9/23.

--- a/Sources/SwiftTAK/COT/COTXMLHelper.swift
+++ b/Sources/SwiftTAK/COT/COTXMLHelper.swift
@@ -1,5 +1,5 @@
 //
-//  XML.swift
+//  COTXMLHelper.swift
 //  
 //
 //  Created by Cory Foy on 9/18/23.

--- a/Sources/SwiftTAK/COT/COTXMLHelper.swift
+++ b/Sources/SwiftTAK/COT/COTXMLHelper.swift
@@ -1,0 +1,50 @@
+//
+//  XML.swift
+//  
+//
+//  Created by Cory Foy on 9/18/23.
+//
+
+import Foundation
+
+public class COTXMLHelper {
+    public static func generateXML(nodeName: String, attributes: [String:String], message: String, includeEmptyAttributes: Bool = false) -> String {
+        let root = XMLElement(name: nodeName, stringValue: message)
+        for attrPair in attributes {
+            if(attrPair.value.isEmpty && !includeEmptyAttributes) {
+                continue
+            }
+            root.addAttribute(XMLNode.attribute(withName: attrPair.key, stringValue: attrPair.value) as! XMLNode)
+        }
+        
+        return root.xmlString
+    }
+    
+    public static func generateXML(nodeName: String, attributes: [String:String], childNodes: [COTNode], includeEmptyAttributes: Bool = false) -> String {
+        let root = XMLElement(name: nodeName)
+        for attrPair in attributes {
+            if(attrPair.value.isEmpty && !includeEmptyAttributes) {
+                continue
+            }
+            root.addAttribute(XMLNode.attribute(withName: attrPair.key, stringValue: attrPair.value) as! XMLNode)
+        }
+
+        for node in childNodes {
+            do {
+                let nodeXml = try XMLElement(xmlString: node.toXml())
+                root.addChild(nodeXml)
+            } catch {
+                TAKLogger.error("Exception adding nodeXML to root from xml \(node.toXml())")
+            }
+        }
+        
+        return root.xmlString
+    }
+}
+
+//func testXmlBlah() {
+//    var root = XMLElement(name: "uid")
+//    root.addAttribute(XMLNode.attribute(withName: "Droid", stringValue: "TESTER-1") as! XMLNode)
+//    let doc = XMLDocument(rootElement: root)
+//    TAKLogger.debug(root.xmlString)
+//}

--- a/Sources/SwiftTAK/COT/XML.swift
+++ b/Sources/SwiftTAK/COT/XML.swift
@@ -1,8 +1,0 @@
-//
-//  XML.swift
-//  
-//
-//  Created by Cory Foy on 9/18/23.
-//
-
-import Foundation

--- a/Sources/SwiftTAK/Utilities/TAKConstants.swift
+++ b/Sources/SwiftTAK/Utilities/TAKConstants.swift
@@ -102,3 +102,58 @@ public enum EmergencyType: String, CaseIterable, CustomStringConvertible, Identi
     
     public var id: Self { self }
 }
+
+public enum HowType: String, CaseIterable, Identifiable {
+    case HumanEstimated = "h-e"
+    case HumanCalculated = "h-c"
+    case HumanTranscribed = "h-t"
+    case HumanCutAndPaste = "h-p"
+    case HumanGIGO = "h-g-i-g-o"
+    case MachineGPSDerived = "m-g"
+    case MachineGPSDerivedAugmented = "m-g-n"
+    case MachineGPSDerivedDifferential = "m-g-d"
+    case MachineMensurated = "m-i"
+    case MachineMagnetic = "m-m"
+    case MachineIns = "m-n"
+    case MachineSimulated = "m-s"
+    case MachineConfigured = "m-c"
+    case MachineRelated = "m-r"
+    case MachinePassed = "m-p"
+    case MachineFused = "m-f"
+    case MachineAlgorithmic = "m-a"
+    case MachineLaserDesignated = "m-l"
+    case MachineRadioEPLRS = "m-R-e"
+    case MachineRadioPLRS = "m-R-p"
+    case MachineRadioDoppler = "m-R-d"
+    case MachineRadioVHF = "m-R-v"
+    case MachineRadioTadil = "m-R-t"
+    case MachineRadioTadilA = "m-R-t-a"
+    case MachineRadioTadilB = "m-R-t-b"
+    case MachineRadioTadilJ = "m-R-t-j"
+    
+    public var id: Self { self }
+}
+
+public enum LinkType: String, CaseIterable, Identifiable {
+    case ParentProducer = "p-p"
+    case ParentOwner = "p-o"
+    case ParentManager = "p-m"
+    case ParentLeader = "p-l"
+    case ChildCorrelated = "c-c"
+    case ChildFused = "c-f"
+    case ChildAlternate = "c-a"
+    case RefinementAmplification = "r-a"
+    case RefinementUrl = "r-u"
+    case TaskingObject = "t-o"
+    case TaskingIndirect = "t-i"
+    case TaskingSubject = "t-s"
+    case TaskingPreposition = "t-p"
+    case TaskingPrepositionAt = "t-p-a"
+    case TaskingPrepositionBy = "t-p-b"
+    case TaskingPrepositionWith = "t-p-w"
+    case TaskingPrepositionFrom = "t-p-f"
+    case TaskingPrepositionRegarding = "t-p-r"
+    case TaskingPrepositionVia = "t-p-v"
+    
+    public var id: Self { self }
+}

--- a/Tests/SwiftTAKTests/COT/COTtoXMLTests.swift
+++ b/Tests/SwiftTAKTests/COT/COTtoXMLTests.swift
@@ -10,93 +10,178 @@ import XCTest
 @testable import SwiftTAK
 
 final class COToXMLTests: XCTestCase {
-    func testCOTChatToXML() {
+    func testCOTChatToXML() throws {
         let expected = "<__chat id='All Chat Rooms' chatroom='All Chat Rooms' groupOwner='TESTGO' parent='12345' senderCallsign='TRACKER-1' messageID='45678' ></__chat>"
         let cotChat = COTChat(id: "All Chat Rooms", chatroom: "All Chat Rooms", groupOwner: "TESTGO", parent: "12345", senderCallsign: "TRACKER-1", messageID: "45678")
-        XCTAssertEqual(expected, cotChat.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotChat.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTContactToXML() {
+    func testCOTContactToXML() throws {
         let expected = "<contact endpoint='*:-1:stcp' phone='2125551212' callsign='TESTGO'></contact>"
         let cotContact = COTContact(endpoint: "*:-1:stcp", phone: "2125551212", callsign: "TESTGO")
-        XCTAssertEqual(expected, cotContact.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotContact.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
-    
-    func testCOTDetailToXML() {
+
+    func testCOTDetailToXML() throws {
         let expected = "<detail></detail>"
         let cotDetail = COTDetail()
-        XCTAssertEqual(expected, cotDetail.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotDetail.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTEmergencyToXML() {
+    func testCOTDetailWithChildNodesToXML() throws {
+        let expected = "<detail><contact callsign='TESTGO' endpoint='*:-1:stcp'></contact></detail>"
+        let cotContact = COTContact(callsign: "TESTGO")
+        var cotDetail = COTDetail()
+        cotDetail.childNodes.append(cotContact)
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotDetail.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
+    }
+    
+    func testCOTEmergencyToXML() throws {
         let expected = "<emergency cancel='true' type='b-a-o-tbl'>TESTGO</emergency>"
         let cotEmergency = COTEmergency(cancel: true, type: EmergencyType.NineOneOne, callsign: "TESTGO")
-        XCTAssertEqual(expected, cotEmergency.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotEmergency.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTEventToXML() {
+    //TODO: Implement Child Nodes
+    func testCOTEventToXML() throws {
         let testDate = Date()
         let testStartDate = testDate.addingTimeInterval(5.0)
         let testStaleDate = testDate.addingTimeInterval(10.0)
         
         let expected = "<event version='2.0' uid='12345' type='a-f-g' how='m-g' time='\(ISO8601DateFormatter().string(from: testDate))' start='\(ISO8601DateFormatter().string(from: testStartDate))' stale='\(ISO8601DateFormatter().string(from: testStaleDate))'></event>"
         let cotEvent = COTEvent(version: "2.0", uid: "12345", type: "a-f-g", how: "m-g", time: testDate, start: testStartDate, stale: testStaleDate)
-        XCTAssertEqual(expected, cotEvent.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotEvent.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTGroupToXML() {
+    func testCOTEventWithChildNodesToXML() throws {
+        let testDate = Date()
+        let testStartDate = testDate.addingTimeInterval(5.0)
+        let testStaleDate = testDate.addingTimeInterval(10.0)
+        let cotPoint = COTPoint(lat: "35.0", lon: "-71.5", hae: "1.0", ce: "2.0", le: "3.0")
+        var cotEvent = COTEvent(version: "2.0", uid: "12345", type: "a-f-g", how: "m-g", time: testDate, start: testStartDate, stale: testStaleDate)
+        cotEvent.childNodes.append(cotPoint)
+        
+        let expected = "<event version='2.0' uid='12345' type='a-f-g' how='m-g' time='\(ISO8601DateFormatter().string(from: testDate))' start='\(ISO8601DateFormatter().string(from: testStartDate))' stale='\(ISO8601DateFormatter().string(from: testStaleDate))'><point lat='35.0' lon='-71.5' hae='1.0' ce='2.0' le='3.0'></point></event>"
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotEvent.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
+    }
+    
+    func testCOTGroupToXML() throws {
         let expected = "<__group name='Cyan' role='Team Member'></__group>"
         let cotGroup = COTGroup(name: "Cyan", role: "Team Member")
-        XCTAssertEqual(expected, cotGroup.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotGroup.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTLinkToXML() {
+    func testCOTLinkToXML() throws {
         let productionTime = ISO8601DateFormatter().string(from: Date())
         let expected = "<link parent_callsign='TESTGO2' production_time='\(productionTime)' relation='p-p' type='a-f-G' uid='12345' callsign='TESTGO' ></link>"
         let cotLink = COTLink(parentCallsign: "TESTGO2", productionTime: productionTime, relation: "p-p", type: "a-f-G", uid: "12345", callsign: "TESTGO")
-        XCTAssertEqual(expected, cotLink.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotLink.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTPointToXML() {
+    func testCOTPointToXML() throws {
         let expected = "<point lat='31.5' lon='-71.5' hae='1.0' ce='2.0' le='3.0'></point>"
         let cotPoint = COTPoint(lat: "31.5", lon: "-71.5", hae: "1.0", ce: "2.0", le: "3.0")
-        XCTAssertEqual(expected, cotPoint.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotPoint.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTRemarksToXML() {
+    func testCOTRemarksToXML() throws {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let expected = "<remarks source='BAO.F.TRACKER' timestamp='\(timestamp)' >Test Message</remarks>"
         let cotRemarks = COTRemarks(source: "BAO.F.TRACKER", timestamp: timestamp, message: "Test Message")
-        XCTAssertEqual(expected, cotRemarks.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotRemarks.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTServerDestinationToXML() {
+    func testCOTServerDestinationToXML() throws {
         let expected = "<__serverdestination destinations='192.168.79.115:4242:tcp'></__serverdestination>"
         let cotServerDestination = COTServerDestination(destinations: "192.168.79.115:4242:tcp")
-        XCTAssertEqual(expected, cotServerDestination.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotServerDestination.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTStatusToXML() {
+    func testCOTStatusToXML() throws {
         let expected = "<status battery='55.0'></status>"
         let cotStatus = COTStatus(battery: "55.0")
-        XCTAssertEqual(expected, cotStatus.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotStatus.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTTakVToXML() {
+    func testCOTTakVToXML() throws {
         let expected = "<takv device='iPhone' platform='Apple' os='iOS' version='17.0'></takv>"
         let cotTakV = COTTakV(device: "iPhone", platform: "Apple", os: "iOS", version: "17.0")
-        XCTAssertEqual(expected, cotTakV.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotTakV.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTTrackToXML() {
+    func testCOTTrackToXML() throws {
         let expected = "<track speed='15.75' course='280.78'></track>"
         let cotTrack = COTTrack(speed: "15.75", course: "280.78")
-        XCTAssertEqual(expected, cotTrack.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotTrack.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
     
-    func testCOTUidToXML() {
+    func testCOTUidToXML() throws {
         let expected = "<uid Droid='TESTGO'></uid>"
         let cotUid = COTUid(callsign: "TESTGO")
-        XCTAssertEqual(expected, cotUid.toXml())
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotUid.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
     }
 }

--- a/Tests/SwiftTAKTests/COT/COTtoXMLTests.swift
+++ b/Tests/SwiftTAKTests/COT/COTtoXMLTests.swift
@@ -1,0 +1,102 @@
+//
+//  COTtoXMLTests.swift
+//  
+//
+//  Created by Cory Foy on 10/9/23.
+//
+
+import XCTest
+
+@testable import SwiftTAK
+
+final class COToXMLTests: XCTestCase {
+    func testCOTChatToXML() {
+        let expected = "<__chat id='All Chat Rooms' chatroom='All Chat Rooms' groupOwner='TESTGO' parent='12345' senderCallsign='TRACKER-1' messageID='45678' ></__chat>"
+        let cotChat = COTChat(id: "All Chat Rooms", chatroom: "All Chat Rooms", groupOwner: "TESTGO", parent: "12345", senderCallsign: "TRACKER-1", messageID: "45678")
+        XCTAssertEqual(expected, cotChat.toXml())
+    }
+    
+    func testCOTContactToXML() {
+        let expected = "<contact endpoint='*:-1:stcp' phone='2125551212' callsign='TESTGO'></contact>"
+        let cotContact = COTContact(endpoint: "*:-1:stcp", phone: "2125551212", callsign: "TESTGO")
+        XCTAssertEqual(expected, cotContact.toXml())
+    }
+    
+    func testCOTDetailToXML() {
+        let expected = "<detail></detail>"
+        let cotDetail = COTDetail()
+        XCTAssertEqual(expected, cotDetail.toXml())
+    }
+    
+    func testCOTEmergencyToXML() {
+        let expected = "<emergency cancel='true' type='b-a-o-tbl'>TESTGO</emergency>"
+        let cotEmergency = COTEmergency(cancel: true, type: EmergencyType.NineOneOne, callsign: "TESTGO")
+        XCTAssertEqual(expected, cotEmergency.toXml())
+    }
+    
+    func testCOTEventToXML() {
+        let testDate = Date()
+        let testStartDate = testDate.addingTimeInterval(5.0)
+        let testStaleDate = testDate.addingTimeInterval(10.0)
+        
+        let expected = "<event version='2.0' uid='12345' type='a-f-g' how='m-g' time='\(ISO8601DateFormatter().string(from: testDate))' start='\(ISO8601DateFormatter().string(from: testStartDate))' stale='\(ISO8601DateFormatter().string(from: testStaleDate))'></event>"
+        let cotEvent = COTEvent(version: "2.0", uid: "12345", type: "a-f-g", how: "m-g", time: testDate, start: testStartDate, stale: testStaleDate)
+        XCTAssertEqual(expected, cotEvent.toXml())
+    }
+    
+    func testCOTGroupToXML() {
+        let expected = "<__group name='Cyan' role='Team Member'></__group>"
+        let cotGroup = COTGroup(name: "Cyan", role: "Team Member")
+        XCTAssertEqual(expected, cotGroup.toXml())
+    }
+    
+    func testCOTLinkToXML() {
+        let productionTime = ISO8601DateFormatter().string(from: Date())
+        let expected = "<link parent_callsign='TESTGO2' production_time='\(productionTime)' relation='p-p' type='a-f-G' uid='12345' callsign='TESTGO' ></link>"
+        let cotLink = COTLink(parentCallsign: "TESTGO2", productionTime: productionTime, relation: "p-p", type: "a-f-G", uid: "12345", callsign: "TESTGO")
+        XCTAssertEqual(expected, cotLink.toXml())
+    }
+    
+    func testCOTPointToXML() {
+        let expected = "<point lat='31.5' lon='-71.5' hae='1.0' ce='2.0' le='3.0'></point>"
+        let cotPoint = COTPoint(lat: "31.5", lon: "-71.5", hae: "1.0", ce: "2.0", le: "3.0")
+        XCTAssertEqual(expected, cotPoint.toXml())
+    }
+    
+    func testCOTRemarksToXML() {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let expected = "<remarks source='BAO.F.TRACKER' timestamp='\(timestamp)' >Test Message</remarks>"
+        let cotRemarks = COTRemarks(source: "BAO.F.TRACKER", timestamp: timestamp, message: "Test Message")
+        XCTAssertEqual(expected, cotRemarks.toXml())
+    }
+    
+    func testCOTServerDestinationToXML() {
+        let expected = "<__serverdestination destinations='192.168.79.115:4242:tcp'></__serverdestination>"
+        let cotServerDestination = COTServerDestination(destinations: "192.168.79.115:4242:tcp")
+        XCTAssertEqual(expected, cotServerDestination.toXml())
+    }
+    
+    func testCOTStatusToXML() {
+        let expected = "<status battery='55.0'></status>"
+        let cotStatus = COTStatus(battery: "55.0")
+        XCTAssertEqual(expected, cotStatus.toXml())
+    }
+    
+    func testCOTTakVToXML() {
+        let expected = "<takv device='iPhone' platform='Apple' os='iOS' version='17.0'></takv>"
+        let cotTakV = COTTakV(device: "iPhone", platform: "Apple", os: "iOS", version: "17.0")
+        XCTAssertEqual(expected, cotTakV.toXml())
+    }
+    
+    func testCOTTrackToXML() {
+        let expected = "<track speed='15.75' course='280.78'></track>"
+        let cotTrack = COTTrack(speed: "15.75", course: "280.78")
+        XCTAssertEqual(expected, cotTrack.toXml())
+    }
+    
+    func testCOTUidToXML() {
+        let expected = "<uid Droid='TESTGO'></uid>"
+        let cotUid = COTUid(callsign: "TESTGO")
+        XCTAssertEqual(expected, cotUid.toXml())
+    }
+}

--- a/Tests/SwiftTAKTests/COT/COTtoXMLTests.swift
+++ b/Tests/SwiftTAKTests/COT/COTtoXMLTests.swift
@@ -184,4 +184,14 @@ final class COToXMLTests: XCTestCase {
         
         XCTAssertEqual(expectedDoc, actualDoc)
     }
+    
+    func testCOTVideoToXML() throws {
+        let expected = "<__video uid='12345' url='https://video.example.com/stream/cam1'></__video>"
+        let cotVideo = COTVideo(url: "https://video.example.com/stream/cam1", uid: "12345")
+        
+        let expectedDoc = try XMLDocument(xmlString: expected)
+        let actualDoc = try XMLDocument(xmlString: cotVideo.toXml())
+        
+        XCTAssertEqual(expectedDoc, actualDoc)
+    }
 }


### PR DESCRIPTION
The early approach of getting `COTNode`s to XML was to hand-construct the XML string. This worked long enough for us to come back in and refactor out construction of the XML to a standard generator using the XML libraries. This also does some clean up / refactoring within the XML generation classes and adds some additional standard enums of both Link and How Types