### PR TITLE
Implements a different XML parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,6 @@ import PackageDescription
 let package = Package(
     name: "SwiftTAK",
     platforms: [
-        .macOS(.v12),
         .iOS(.v15),
     ],
     products: [

--- a/Sources/SwiftTAK/COT/COTMessage.swift
+++ b/Sources/SwiftTAK/COT/COTMessage.swift
@@ -40,12 +40,13 @@ public class COTMessage: NSObject {
     static public let DEFAULT_ERROR_NUMBER = "999999.0"
     public let COT_EVENT_VERSION = "2.0"
     
-    var staleTimeMinutes : Double
-    var deviceID : String
-    var phoneModel : String
-    var appPlatform : String
-    var phoneOS : String
-    var appVersion : String
+    var staleTimeMinutes: Double
+    var deviceID: String
+    var phoneModel: String
+    var appPlatform: String
+    var phoneOS: String
+    var appVersion: String
+    var dateFormatter = ISO8601DateFormatter()
     
     public init(staleTimeMinutes: Double = 5.0,
          deviceID: String = UUID().uuidString,
@@ -166,7 +167,7 @@ public class COTMessage: NSObject {
         
         let cotChat = COTChat(senderCallsign: from, messageID: messageID)
         let cotLink = COTLink(relation: LinkType.ParentProducer.rawValue, type: "a-f-G-U-C", uid: messageID)
-        let cotRemarks = COTRemarks(source: remarksSource, timestamp: Date().ISO8601Format(), message: message)
+        let cotRemarks = COTRemarks(source: remarksSource, timestamp: dateFormatter.string(from: Date()), message: message)
         
         cotDetail.childNodes.append(cotChat)
         cotDetail.childNodes.append(cotLink)

--- a/Sources/SwiftTAK/COT/COTXMLHelper.swift
+++ b/Sources/SwiftTAK/COT/COTXMLHelper.swift
@@ -14,7 +14,7 @@ public class COTXMLHelper {
             if(attrPair.value.isEmpty && !includeEmptyAttributes) {
                 continue
             }
-            root.addAttribute(XMLNode.attribute(withName: attrPair.key, stringValue: attrPair.value) as! XMLNode)
+            root.addAttribute(XMLNode.attribute(withName: attrPair.key, stringValue: attrPair.value))
         }
         
         return root.xmlString
@@ -26,7 +26,7 @@ public class COTXMLHelper {
             if(attrPair.value.isEmpty && !includeEmptyAttributes) {
                 continue
             }
-            root.addAttribute(XMLNode.attribute(withName: attrPair.key, stringValue: attrPair.value) as! XMLNode)
+            root.addAttribute(XMLNode.attribute(withName: attrPair.key, stringValue: attrPair.value))
         }
 
         for node in childNodes {
@@ -41,10 +41,3 @@ public class COTXMLHelper {
         return root.xmlString
     }
 }
-
-//func testXmlBlah() {
-//    var root = XMLElement(name: "uid")
-//    root.addAttribute(XMLNode.attribute(withName: "Droid", stringValue: "TESTER-1") as! XMLNode)
-//    let doc = XMLDocument(rootElement: root)
-//    TAKLogger.debug(root.xmlString)
-//}

--- a/Sources/SwiftTAK/Parsers/XML/XMLDocument.swift
+++ b/Sources/SwiftTAK/Parsers/XML/XMLDocument.swift
@@ -1,0 +1,75 @@
+//
+//  XMLDocument.swift
+//  
+//
+//  Created by Cory Foy on 10/10/23.
+//
+
+import Foundation
+
+class XMLDocument: Equatable {
+    var rootNode: XMLNode
+    
+    init(xmlString: String) throws {
+        let nodeParser = XMLNode(key: "", value: "")
+        let xmlParser = XMLParser(data: Data(xmlString.utf8))
+        xmlParser.delegate = nodeParser
+        xmlParser.parse()
+        rootNode = XMLNode(key: nodeParser.key, value: nodeParser.stringValue)
+        rootNode.attributes = nodeParser.attributes
+        rootNode.childNodes = nodeParser.childNodes
+    }
+    
+    func nodes(forXPath: String) throws -> [XMLNode] {
+        var results: [XMLNode] = []
+        let isRecursive = forXPath.starts(with: "//")
+        let components = forXPath.split(separator: "/")
+        for component in components {
+            let subcomponents = component.split(separator: "[")
+            var nodeName = ""
+            var attrName = ""
+            var attrValue = ""
+
+            if(subcomponents.count > 1) {
+                nodeName = String(subcomponents.first!)
+                var attrPart = String(subcomponents.last!)
+                attrPart = attrPart.replacingOccurrences(of: "@", with: "")
+                attrPart = attrPart.replacingOccurrences(of: "]", with: "")
+                attrPart = attrPart.replacingOccurrences(of: "'", with: "")
+                let attrComponents = attrPart.split(separator: "=")
+                attrName = String(attrComponents.first!)
+                attrValue = String(attrComponents.last!)
+            } else {
+                nodeName = String(component)
+            }
+            
+            if(doesMatch(node: rootNode, nodeName: nodeName, attrName: attrName, attrValue: attrValue)) {
+                results.append(rootNode)
+            }
+            
+            if(isRecursive) {
+                for node in rootNode.childNodes {
+                    if(doesMatch(node: node, nodeName: nodeName, attrName: attrName, attrValue: attrValue)) {
+                        results.append(node)
+                    }
+                }
+            }
+        }
+        return results
+    }
+    
+    private func doesMatch(node: XMLNode, nodeName: String, attrName: String = "", attrValue: String = "") -> Bool {
+        var doesMatch = false
+        doesMatch = node.key == nodeName
+        if(doesMatch && !attrName.isEmpty) {
+            doesMatch = node.attributes[attrName] == attrValue
+        }
+        return doesMatch
+    }
+    
+    static func == (lhs: XMLDocument, rhs: XMLDocument) -> Bool {
+        return lhs.rootNode.key == rhs.rootNode.key &&
+        lhs.rootNode.stringValue == rhs.rootNode.stringValue &&
+        lhs.rootNode.attributes == rhs.rootNode.attributes
+    }
+}

--- a/Sources/SwiftTAK/Parsers/XML/XMLElement.swift
+++ b/Sources/SwiftTAK/Parsers/XML/XMLElement.swift
@@ -1,0 +1,50 @@
+//
+//  XMLElement.swift
+//  
+//
+//  Created by Cory Foy on 10/10/23.
+//
+
+import Foundation
+
+class XMLElement : XMLNode {
+    
+    init(xmlString: String) throws {
+        let nodeParser = XMLNode(key: "", value: "")
+        let xmlParser = XMLParser(data: Data(xmlString.utf8))
+        xmlParser.delegate = nodeParser
+        xmlParser.parse()
+        super.init(key: nodeParser.key, value: nodeParser.stringValue)
+        self.attributes = nodeParser.attributes
+        self.childNodes = nodeParser.childNodes
+        self.xmlString = xmlString
+    }
+    
+    init(name: String, stringValue: String) {
+        super.init(key: name, value: stringValue)
+        regenXmlString()
+    }
+    
+    init(name: String) {
+        super.init(key: name, value: "")
+        regenXmlString()
+    }
+    
+    func addAttribute(_ node: XMLNode) {
+        attributes[node.key] = node.stringValue
+        regenXmlString()
+    }
+    
+    func addChild(_ node: XMLElement) {
+        childNodes.append(node)
+        regenXmlString()
+    }
+    
+    func attribute(forName: String) -> XMLNode? {
+        let attrVal = attributes[forName]
+        if(attrVal == nil) {
+            return nil
+        }
+        return XMLNode(key: forName, value: attrVal!)
+    }
+}

--- a/Sources/SwiftTAK/Parsers/XML/XMLNode.swift
+++ b/Sources/SwiftTAK/Parsers/XML/XMLNode.swift
@@ -1,0 +1,80 @@
+//
+//  XMLNode.swift
+//  
+//
+//  Created by Cory Foy on 10/10/23.
+//
+
+import Foundation
+
+class XMLNode: NSObject, XMLParserDelegate {
+    var key: String
+    var stringValue: String
+    var attributes: [String:String] = [:]
+    var childNodes: [XMLElement] = []
+    var xmlString = ""
+    private var textBuffer: String = ""
+    private var currentAttr: String = ""
+    private var tempNodes: [String:XMLElement] = [:]
+    
+    public init(key: String, value: String) {
+        self.key = key
+        self.stringValue = value
+    }
+    
+    public static func attribute(withName: String, stringValue: String) -> XMLNode {
+        return XMLNode(key: withName, value: stringValue)
+    }
+    
+    public func parser(_ parser: XMLParser, foundCharacters string: String) {
+        textBuffer += string
+    }
+    
+    public func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+        let node = tempNodes[elementName]
+        if(node != nil) {
+            node!.stringValue = textBuffer
+            if(key.isEmpty) {
+                key = node!.key
+                stringValue = node!.stringValue
+                attributes = node!.attributes
+            } else {
+                childNodes.append(node!)
+            }
+            tempNodes.removeValue(forKey: elementName)
+        }
+        textBuffer = ""
+    }
+    
+    public func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String : String] = [:]
+    ) {
+        let node = XMLElement(name: elementName, stringValue: "")
+        for (attr_key, attr_val) in attributeDict {
+            node.attributes[attr_key] = attr_val
+        }
+        tempNodes[elementName] = node
+    }
+    
+    func regenXmlString() {
+        var tmpStr = ""
+        tmpStr += "<\(key)"
+        for attrPair in attributes {
+            tmpStr += " \(attrPair.key)='\(attrPair.value)'"
+        }
+        tmpStr += ">"
+        if(stringValue.isEmpty) {
+            for node in childNodes {
+                tmpStr += node.xmlString
+            }
+        } else {
+            tmpStr += stringValue
+        }
+        tmpStr += "</\(key)>"
+        xmlString = tmpStr
+    }
+}

--- a/Tests/SwiftTAKTests/COT/XMLTests.swift
+++ b/Tests/SwiftTAKTests/COT/XMLTests.swift
@@ -57,14 +57,14 @@ final class XMLTests: XCTestCase {
         TAKLogger.debug(result)
         
         let actualDoc = try XMLDocument(xmlString: result)
-        let chatNode = try actualDoc.nodes(forXPath: "//__chat").first! as? XMLElement
-        let remarksNode = try actualDoc.nodes(forXPath: "//remarks").first! as? XMLElement
+        let chatNode = try actualDoc.nodes(forXPath: "//__chat").first! as! XMLElement
+        let remarksNode = try actualDoc.nodes(forXPath: "//remarks").first! as! XMLElement
         
-        XCTAssertEqual(chatNode!.attribute(forName: "id")!.stringValue, "All Chat Rooms")
-        XCTAssertEqual(chatNode!.attribute(forName: "chatroom")!.stringValue, "All Chat Rooms")
-        XCTAssertEqual(chatNode!.attribute(forName: "senderCallsign")!.stringValue, "TEST-TRACKER")
+        XCTAssertEqual(chatNode.attribute(forName: "id")!.stringValue, "All Chat Rooms")
+        XCTAssertEqual(chatNode.attribute(forName: "chatroom")!.stringValue, "All Chat Rooms")
+        XCTAssertEqual(chatNode.attribute(forName: "senderCallsign")!.stringValue, "TEST-TRACKER")
         
-        XCTAssertEqual(remarksNode!.attribute(forName: "source")!.stringValue, "BAO.F.TAKTracker.TEST-TRACKER")
-        XCTAssertEqual(remarksNode!.stringValue, "Hello, World")
+        XCTAssertEqual(remarksNode.attribute(forName: "source")!.stringValue, "BAO.F.TAKTracker.TEST-TRACKER")
+        XCTAssertEqual(remarksNode.stringValue, "Hello, World")
     }
 }


### PR DESCRIPTION
In PR #4 we standardized the COT -> XML away from string interpolation to use XML classes. What wasn't apparent was the project was targeting both iOS and macOS, and `XMLDocument` is [only available on macOS](https://developer.apple.com/forums/thread/651377). This caused significant issues for downstream consumers that were iOS only.

After looking around there were not many good modern solutions / projects bringing XML Documents to Swift, and we only use it in a very limited subset, so this PR implements the three primary XML classes we were using. It attempts to follow the standard signature of the macOS libraries in case we can ever pull that in. But it does not implement a full-fledged parser - this is quite literally just good enough for our needs.