### PR TITLE
Fixes issue when prefs file and root file name are the same

### DIFF
--- a/Sources/SwiftTAK/Parsers/DataPackagerParser.swift
+++ b/Sources/SwiftTAK/Parsers/DataPackagerParser.swift
@@ -50,12 +50,18 @@ public class DataPackageParser: NSObject {
             return fileData
         }
         
-        if(!packageContents.rootFolder.isEmpty &&
-           !fileLocation.contains(packageContents.rootFolder)) {
-            let root = packageContents.rootFolder
-            fileLocation = root.appending("/").appending(fileLocation)
+        let pathComponents = fileLocation.split(separator: "/")
+        
+        if(!packageContents.rootFolder.isEmpty) {
+            if(pathComponents.count > 1 && pathComponents.first! == packageContents.rootFolder) {
+                TAKLogger.debug("[DataPackageParser]: Not applying a root folder since it appears to already be in place")
+            } else {
+                let root = packageContents.rootFolder
+                fileLocation = root.appending("/").appending(fileLocation)
+            }
         }
         
+        TAKLogger.debug("[DataPackageParser]: Attempting to load \(fileLocation) from archive")
         guard let fileEntry = archive[fileLocation]
         else { TAKLogger.debug("[DataPackageParser]: file \(fileLocation) not found in archive"); return fileData }
         
@@ -98,9 +104,9 @@ public class DataPackageParser: NSObject {
     }
     
     func storeRootDirectory(prefsFileLocation: String) {
-        let prefsFileURL = URL(string: prefsFileLocation)
-        if(prefsFileURL != nil && prefsFileURL!.pathComponents.count > 1) {
-            packageContents.rootFolder = prefsFileURL!.pathComponents.first!
+        let pathComponents = prefsFileLocation.split(separator: "/")
+        if(pathComponents.count > 1) {
+            packageContents.rootFolder = String(pathComponents.first!)
         }
     }
     

--- a/Tests/SwiftTAKTests/Parsers/DataPackageParserTests.swift
+++ b/Tests/SwiftTAKTests/Parsers/DataPackageParserTests.swift
@@ -135,7 +135,7 @@ final class InvalidDataPackageTests: DataPackageParserTests {
     }
 }
 
-class DataPackageParserTests: XCTestCase {
+class DataPackageParserTests: SwiftTAKTestCase {
     
     func dataPackageFilename() -> String {
         return ""
@@ -156,6 +156,7 @@ class DataPackageParserTests: XCTestCase {
         parser.parse()
         TAKLogger.debug(parser.packageContents.serverCertificate.count.description)
         TAKLogger.debug(Data().count.description)
+        TAKLogger.debug(parser.packageContents.serverCertificate.count.description)
         XCTAssertFalse(parser.packageContents.serverCertificate.isEmpty)
     }
     

--- a/Tests/SwiftTAKTests/SwiftTAKTestCase.swift
+++ b/Tests/SwiftTAKTests/SwiftTAKTestCase.swift
@@ -1,0 +1,18 @@
+//
+//  SwiftTAKTestCase.swift
+//  
+//
+//  Created by Cory Foy on 10/10/23.
+//
+
+import Foundation
+import XCTest
+
+class SwiftTAKTestCase : XCTestCase {
+    override class func setUp() {
+        if let bundleID = Bundle.main.bundleIdentifier {
+            UserDefaults.standard.removePersistentDomain(forName: bundleID)
+            UserDefaults.standard.synchronize()
+        }
+    }
+}


### PR DESCRIPTION
In fixing Issue #2 we introduced the concept of a "root folder" which then got appended when attempting to load files from the archive. There was a check in place to see if the root folder name was already in the file location to avoid double appending. However, some data packages use the name of the subfolder as the name of the `prefs` file, so the root folder wasn't getting appended. This fixes that issue.